### PR TITLE
Fix AttributeError on window close for macOS with pyglet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # scikit-robot-pyrender
 
 [![Run Tests](https://github.com/iory/scikit-robot-pyrender/actions/workflows/test.yml/badge.svg)](https://github.com/iory/scikit-robot-pyrender/actions/workflows/test.yml)
+![Python Versions](https://img.shields.io/pypi/pyversions/scikit-robot-pyrender.svg)
 [![PyPI version](https://badge.fury.io/py/scikit-robot-pyrender.svg)](https://badge.fury.io/py/scikit-robot-pyrender)
 
 A fork of [pyrender](https://github.com/mmatl/pyrender) with enhanced OpenGL compatibility.

--- a/pyrender/viewer.py
+++ b/pyrender/viewer.py
@@ -572,7 +572,15 @@ class Viewer(pyglet.window.Window):
         finally:
             self._is_active = False
             super(Viewer, self).on_close()
-            pyglet.app.exit()
+            # Handle macOS-specific issue with CocoaAlternateEventLoop
+            if sys.platform == 'darwin':
+                try:
+                    pyglet.app.exit()
+                except AttributeError:
+                    # CocoaAlternateEventLoop may not have platform_event_loop attribute
+                    pass
+            else:
+                pyglet.app.exit()
 
     def on_draw(self):
         """Redraw the scene into the viewing window.


### PR DESCRIPTION
## Summary
- Fixed an issue where closing the pyrender viewer window on macOS raises an AttributeError
- The error occurs when pyglet tries to exit but CocoaAlternateEventLoop doesn't have the platform_event_loop attribute
- Added platform-specific error handling for macOS while preserving existing behavior on other platforms

## Problem
When using the pyrender viewer on macOS and closing the window (especially with the Q key), the following error occurs:
```
AttributeError: 'CocoaAlternateEventLoop' object has no attribute 'platform_event_loop'
```

## Solution
Wrapped the `pyglet.app.exit()` call in a platform-specific try-except block for macOS (`sys.platform == 'darwin'`) to catch and suppress the AttributeError. Other platforms continue to use the original code path without modification.

## Test plan
- [x] Tested on macOS with `visualize-urdf` command
- [x] Verified the viewer closes without errors when pressing Q key
- [x] Ensured the fix only applies to macOS platform